### PR TITLE
Update compatibility for Python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest matplotlib==3.10 pandas plotly
+        pip install pytest matplotlib==3.10.3 pandas==2.3.1 plotly==6.2.0
     - name: Test with pytest
       run: |
         pytest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ site/
 docs/
 data/
 tests/videos
+!tests/videos/.gitkeep

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://img.shields.io/pypi/v/bar_chart_racer)](https://pypi.org/project/bar_chart_racer)
 [![PyPI - License](https://img.shields.io/pypi/l/bar_chart_racer)](LICENSE)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/release/python-3110/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/release/python-3120/)
 
 Make animated bar and line chart races in Python with matplotlib and plotly.
 
@@ -14,10 +14,10 @@ Visit the [bar_chart_racer official documentation](https://github.com/sofus-nl/b
 
 ## Requirements
 
-- Python 3.11 or higher
-- pandas 2.0.0 or higher
-- matplotlib 3.7.0 or higher
-- plotly 5.13.0 or higher
+- Python 3.12 or higher
+- pandas 2.3.1 or higher
+- matplotlib 3.10.3 or higher
+- plotly 6.2.0 or higher
 
 ## Installation
 

--- a/REFACTORING_SUMMARY.md
+++ b/REFACTORING_SUMMARY.md
@@ -4,16 +4,16 @@
 
 This project has been refactored from `bar_chart_race` to `bar_chart_racer` with the following key improvements:
 
-1. **Python 3.11+ Compatibility**
-   - Updated Python requirement from 3.6+ to 3.11+
+1. **Python 3.12+ Compatibility**
+   - Updated Python requirement from 3.6+ to 3.12+
    - Added comprehensive type hints throughout the codebase
    - Modernized string formatting using f-strings
    - Improved error handling with more specific exceptions
 
 2. **Dependency Updates**
-   - Updated pandas requirement to 2.0.0+
-   - Updated matplotlib requirement to 3.7.0+
-   - Made plotly a required dependency (5.13.0+)
+   - Updated pandas requirement to 2.3.1+
+   - Updated matplotlib requirement to 3.10.3+
+   - Made plotly a required dependency (6.2.0+)
 
 3. **Package Structure Improvements**
    - Added py.typed marker file for PEP 561 compliance

--- a/bar_chart_racer/_codes/code_value.csv
+++ b/bar_chart_racer/_codes/code_value.csv
@@ -1,3 +1,3 @@
 code,value
-country,https://github.com/hjnilsson/country-flags/raw/master/png250px/{code}.png
+country,https://flagcdn.com/w320/{code}.png
 nfl,self

--- a/bar_chart_racer/_line_chart_race.py
+++ b/bar_chart_racer/_line_chart_race.py
@@ -9,6 +9,8 @@ from matplotlib.collections import LineCollection
 from matplotlib import ticker, colors as mcolors, dates as mdates
 from matplotlib import image as mimage
 from matplotlib import patches as mpatches
+import urllib.request
+from io import BytesIO
 
 from ._common_chart import CommonChart
 from ._utils import prepare_wide_data
@@ -307,7 +309,15 @@ class _LineChartRace(CommonChart):
             raise ValueError('The number of images does not match the number of columns')
         if isinstance(images, list):
             images = dict(zip(self.df_values.columns, images))
-        return {col: mimage.imread(image) for col, image in images.items()}
+
+        def read_image(obj):
+            if isinstance(obj, str) and obj.startswith('http'):
+                with urllib.request.urlopen(obj) as url:
+                    data = url.read()
+                return mimage.imread(BytesIO(data))
+            return mimage.imread(obj)
+
+        return {col: read_image(img) for col, img in images.items()}
             
     def get_visible(self, i):
         n = 1_000_000 # make all visible until better logic here
@@ -366,7 +376,11 @@ class _LineChartRace(CommonChart):
             collection.set_color(color_arr)
 
             is_other_agg = col in ('___others_line___', '___agg_line___')
-            if self.line_width_data is not None and not is_other_agg:
+            if (
+                self.line_width_data is not None
+                and not is_other_agg
+                and col in self.line_width_data.columns
+            ):
                 lw = self.line_width_data.iloc[i // self.steps_per_period][col]
                 lw_arr = collection.get_linewidths()
                 lw_arr = np.append(lw_arr, [lw], axis=0)
@@ -433,7 +447,7 @@ class _LineChartRace(CommonChart):
             ls = self.line_kwargs['ls']
             alpha = self.line_kwargs.get('alpha', 1)
             color[-1] = alpha
-            if self.line_width_data is not None:
+            if self.line_width_data is not None and col in self.line_width_data.columns:
                 lw = self.line_width_data.iloc[0][col]
             lc = LineCollection([[(x, val)]], colors=[color], visible=vis, linewidths=[lw], linestyles=[ls])
             collection = ax.add_collection(lc)

--- a/bar_chart_racer/_utils.py
+++ b/bar_chart_racer/_utils.py
@@ -4,13 +4,14 @@ from typing import Dict, List, Literal, Optional, Tuple, Union, Any, Callable
 import pandas as pd
 import numpy as np
 import PIL
-import urllib
+import urllib.request
 
 
 def load_dataset(name: str = 'covid19') -> pd.DataFrame:
     '''
     Return a pandas DataFrame suitable for immediate use in `bar_chart_race`.
-    Must be connected to the internet
+    Will attempt to load the dataset from the local package first and
+    download from GitHub if it is not available locally.
 
     Parameters
     ----------
@@ -32,8 +33,7 @@ def load_dataset(name: str = 'covid19') -> pd.DataFrame:
     ValueError
         If the dataset name is not recognized
     '''
-    # TODO: Update this URL to your own repository once you've uploaded the data files
-    url = f'https://raw.githubusercontent.com/dexplo/bar_chart_race/master/data/{name}.csv'
+    url = f'https://raw.githubusercontent.com/sofus-nl/bar_chart_racer/main/data/{name}.csv'
 
     index_dict = {
         'covid19_tutorial': 'date',
@@ -51,6 +51,11 @@ def load_dataset(name: str = 'covid19') -> pd.DataFrame:
     index_col = index_dict[name]
     parse_dates = [index_col] if index_col else None
     
+    # Attempt to load the dataset from the local package data directory first
+    local_path = Path(__file__).resolve().parent.parent / 'data' / f'{name}.csv'
+    if local_path.exists():
+        return pd.read_csv(local_path, index_col=index_col, parse_dates=parse_dates)
+
     try:
         return pd.read_csv(url, index_col=index_col, parse_dates=parse_dates)
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -12,29 +12,29 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="bar_chart_racer",
     version=version,
-    author="Wibo van der Sluis",  # TODO: Update with your name
-    author_email="wibo@sofus.nl",  # TODO: Update with your email
+    author="Wibo van der Sluis",
+    author_email="wibo@sofus.nl",
     description="Create animated bar chart races using matplotlib and plotly",
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords="visualization animation bar chart race matplotlib pandas plotly",
-    url="https://github.com/sofus-nl/bar_chart_racer",  # TODO: Update with your GitHub username
+    url="https://github.com/sofus-nl/bar_chart_racer",
     packages=setuptools.find_packages(),
     license='MIT',
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Visualization",
     ],
     install_requires=[
-        "pandas>=2.0.0",
-        "matplotlib>=3.7.0",
-        "plotly>=5.13.0",
+        "pandas>=2.3.1",
+        "matplotlib>=3.10.3",
+        "plotly>=6.2.0",
     ],
-    python_requires='>=3.11',
+    python_requires='>=3.12',
     include_package_data=True,
 )


### PR DESCRIPTION
## Summary
- update README requirements for Python 3.12 and latest library versions
- bump required versions in setup.py
- refresh refactoring summary with new minimum versions
- test workflow uses Python 3.12 and new library pins
- fix dataset URLs and fallback to local CSVs
- update image download source and handle remote images
- ensure videos directory exists for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800a0d233c8333a501fe9aea2ffb90